### PR TITLE
Fix Duplicate Foreign Key on Migration

### DIFF
--- a/database/migrations/2024_05_14_181631_add_cascade_fk.php
+++ b/database/migrations/2024_05_14_181631_add_cascade_fk.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('bookings', function (Blueprint $table) {
-            if (Schema::hasColumn('bookings', 'bookings_vehicle_id_foreign')) {
+            if (Schema::hasColumn('bookings', 'vehicle_id')) {
                 $table->dropForeign(['vehicle_id']);
             }
 


### PR DESCRIPTION
Corrects a typo in the `2024_05_14_181631_add_cascade_fk` migration where it was checking for the existence of the foreign key constraint instead of the column it's applied to. This fixes issue #1 